### PR TITLE
Add templates for required Krimi‑Dinner documents

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,22 @@
+# Templates für ein fertiges Krimi-Dinner-Spiel
+
+Diese Vorlagen enthalten **nur Struktur und Anforderungen** – keine Story, Rollen, Hinweise oder Auflösungstexte.
+Nutze sie, um ein vollständiges Spiel konsistent zu dokumentieren.
+
+## Pflichtdokumente (Vorlagen in diesem Ordner)
+1. `spielanleitung-material-einfuehrungstext.md`
+2. `einladung.md`
+3. `rollenbeschreibung.md` (pro Rolle eine Datei)
+4. `hinweise.md` (pro Rolle eine Datei)
+5. `ermittlungsergebnisse-inspektor.md`
+6. `aufloesung.md`
+7. `ortsbeschreibung.md`
+8. `charakteruebersicht.md`
+9. `hinweisuebersicht-pro-runde.md`
+10. `kurzfassung-pro-runde.md`
+11. `entscheidendes-merkmal.md`
+
+## Ausfüll-Hinweise
+- **Platzhalter** sind in eckigen Klammern geschrieben (z. B. `[Name der Rolle]`).
+- **Keine Story-Details** hinzufügen, solange Anforderungen gesammelt werden.
+- Jede Rolle erhält eigene Dateien für Rollenbeschreibung und Hinweise.

--- a/templates/aufloesung.md
+++ b/templates/aufloesung.md
@@ -1,0 +1,21 @@
+# Auflösung – Vorlage
+
+## Zweck
+[Zusammenfassung der tatsächlichen Ereignisse und der Überführung.]
+
+## Täter:in
+- **Name:** [Name]
+- **Motiv:** [Motiv]
+
+## Tatablauf (Kurzfassung)
+1. [Ereignis 1]
+2. [Ereignis 2]
+3. [Ereignis 3]
+
+## Wichtige Beweise
+- [Beweis 1]
+- [Beweis 2]
+
+## Wie die Hinweise zur Auflösung führen
+- [Hinweis/Schlussfolgerung 1]
+- [Hinweis/Schlussfolgerung 2]

--- a/templates/charakteruebersicht.md
+++ b/templates/charakteruebersicht.md
@@ -1,0 +1,13 @@
+# Charakterübersicht – Vorlage
+
+## Zweck
+[Kurzübersicht aller Rollen für Gastgeber:in oder Spielleitung.]
+
+## Rollenliste
+- **[Rolle 1]:** [Kurzbeschreibung]
+- **[Rolle 2]:** [Kurzbeschreibung]
+- **[Rolle 3]:** [Kurzbeschreibung]
+- **[Rolle 4]:** [Kurzbeschreibung]
+
+## Beziehungsmatrix (optional)
+[Platzhalter für Tabelle/Matrix.]

--- a/templates/einladung.md
+++ b/templates/einladung.md
@@ -1,0 +1,21 @@
+# Einladung – Vorlage
+
+## Zweck
+[Kurzer Hinweis, dass dies die Einladung an Spieler:innen ist.]
+
+## Veranstaltung
+- **Titel/Anlass:** [Titel des Krimi-Dinners]
+- **Datum/Uhrzeit:** [Datum, Uhrzeit]
+- **Ort:** [Adresse/Ort]
+- **Dresscode (optional):** [z. B. 20er Jahre]
+
+## Rollenvergabe
+- **Deine Rolle:** [Name der Rolle]
+- **Kurzbeschreibung:** [1–2 Sätze ohne Spoiler]
+
+## Vorbereitung
+- **Bitte lesen:** [Rollenbeschreibung vorab?]
+- **Mitbringen:** [optional]
+
+## Ablauf-Hinweis
+[Kurzer Hinweis zum Spielablauf ohne Spoiler.]

--- a/templates/entscheidendes-merkmal.md
+++ b/templates/entscheidendes-merkmal.md
@@ -1,0 +1,12 @@
+# Entscheidendes Merkmal – Vorlage
+
+## Zweck
+[Das eine zentrale Merkmal, das am Ende die Täter:in überführt.]
+
+## Merkmal
+- **Beschreibung:** [Platzhalter]
+- **Warum entscheidend:** [Platzhalter]
+
+## Hinweisverankerung
+- [Welcher Hinweis verweist darauf?]
+- [In welcher Runde wird es bekannt?]

--- a/templates/ermittlungsergebnisse-inspektor.md
+++ b/templates/ermittlungsergebnisse-inspektor.md
@@ -1,0 +1,16 @@
+# Ermittlungsergebnisse – Vorlage (Inspektor)
+
+## Zweck
+[Vorlesetexte pro Hinweisrunde, die den Ermittlungsstand zusammenfassen.]
+
+## Hinweisrunde 1
+- [Ermittlungsergebnis 1]
+- [Ermittlungsergebnis 2]
+
+## Hinweisrunde 2
+- [Ermittlungsergebnis 1]
+- [Ermittlungsergebnis 2]
+
+## Hinweisrunde 3
+- [Ermittlungsergebnis 1]
+- [Ermittlungsergebnis 2]

--- a/templates/hinweise.md
+++ b/templates/hinweise.md
@@ -1,0 +1,23 @@
+# Hinweise – Vorlage
+
+## Rolle
+- **Name:** [Name der Rolle]
+
+## Hinweisrunde 1
+- **Hinweis 1:** [Platzhalter]
+- **Hinweis 2:** [Platzhalter]
+- **Hinweis 3:** [Platzhalter]
+
+## Hinweisrunde 2
+- **Hinweis 1:** [Platzhalter]
+- **Hinweis 2:** [Platzhalter]
+- **Hinweis 3:** [Platzhalter]
+
+## Hinweisrunde 3
+- **Hinweis 1:** [Platzhalter]
+- **Hinweis 2:** [Platzhalter]
+- **Hinweis 3:** [Platzhalter]
+
+## Gerüchte (optional)
+- **Gerücht 1:** [Platzhalter]
+- **Gerücht 2:** [Platzhalter]

--- a/templates/hinweisuebersicht-pro-runde.md
+++ b/templates/hinweisuebersicht-pro-runde.md
@@ -1,0 +1,19 @@
+# Hinweisübersicht pro Runde – Vorlage
+
+## Zweck
+[Kurze Übersicht, welche Hinweise je Runde existieren und wie sie verteilt sind.]
+
+## Runde 1
+| Rolle | Hinweis(e) | Pflicht? |
+| --- | --- | --- |
+| [Rolle] | [Hinweis] | [Ja/Nein] |
+
+## Runde 2
+| Rolle | Hinweis(e) | Pflicht? |
+| --- | --- | --- |
+| [Rolle] | [Hinweis] | [Ja/Nein] |
+
+## Runde 3
+| Rolle | Hinweis(e) | Pflicht? |
+| --- | --- | --- |
+| [Rolle] | [Hinweis] | [Ja/Nein] |

--- a/templates/kurzfassung-pro-runde.md
+++ b/templates/kurzfassung-pro-runde.md
@@ -1,0 +1,16 @@
+# Kurzfassung pro Runde – Vorlage
+
+## Zweck
+[Knackige Zusammenfassung, was in jeder Runde bekannt sein sollte.]
+
+## Runde 1 – Kurzfassung
+- [Punkt 1]
+- [Punkt 2]
+
+## Runde 2 – Kurzfassung
+- [Punkt 1]
+- [Punkt 2]
+
+## Runde 3 – Kurzfassung
+- [Punkt 1]
+- [Punkt 2]

--- a/templates/ortsbeschreibung.md
+++ b/templates/ortsbeschreibung.md
@@ -1,0 +1,14 @@
+# Ortsbeschreibung – Vorlage
+
+## Ort
+- **Name:** [Name des Ortes]
+- **Art:** [z. B. Herrenhaus, Hotel]
+- **Zeit/Rahmen:** [Zeitperiode]
+
+## Kurzbeschreibung
+[Kurzer, stimmungsvoller Überblick ohne konkrete Storydetails.]
+
+## Wichtige Bereiche
+- [Bereich 1 – Beschreibung]
+- [Bereich 2 – Beschreibung]
+- [Bereich 3 – Beschreibung]

--- a/templates/rollenbeschreibung.md
+++ b/templates/rollenbeschreibung.md
@@ -1,0 +1,31 @@
+# Rollenbeschreibung – Vorlage
+
+## Rolle
+- **Name:** [Name der Rolle]
+- **Alter:** [Alter/Spanne]
+- **Beruf/Status:** [Beruf/Status]
+- **Beziehung zum Opfer:** [Beziehung]
+
+## Hintergrund
+[Allgemeiner Hintergrund ohne konkrete Storydetails.]
+
+## Persönlichkeit & Auftreten
+- [Eigenschaft 1]
+- [Eigenschaft 2]
+- [Eigenschaft 3]
+
+## Beziehungen zu anderen Rollen
+- **[Rolle A]:** [Art der Beziehung]
+- **[Rolle B]:** [Art der Beziehung]
+- **[Rolle C]:** [Art der Beziehung]
+
+## Wissen/Informationen (ohne Hinweise)
+- [Was die Rolle grundsätzlich weiß]
+
+## Ziele/Agenda
+- [Ziel 1]
+- [Ziel 2]
+
+## Offene Fragen (für Improvisation)
+- [Frage 1]
+- [Frage 2]

--- a/templates/spielanleitung-material-einfuehrungstext.md
+++ b/templates/spielanleitung-material-einfuehrungstext.md
@@ -1,0 +1,38 @@
+# Spielanleitung, Material & Einführungstext – Vorlage
+
+## Zweck
+[Beschreibe kurz den Zweck des Dokuments.]
+
+## Spielziel
+- [Ziel des Spiels in 1–2 Sätzen.]
+
+## Dauer & Rahmen
+- **Empfohlene Dauer:** [z. B. 2–4 Stunden]
+- **Empfohlene Spielerzahl:** [Zahl/Spanne]
+- **Hinweis zu Verkleidung/Atmosphäre:** [optional]
+
+## Materialliste
+- [Einladung]
+- [Rollenbeschreibungen]
+- [Hinweise pro Rolle]
+- [Ermittlungsergebnisse Inspektor]
+- [Auflösung]
+- [Namenskarten]
+- [Optionale Requisiten]
+
+## Spielablauf (Phasen)
+1. **Einführung:** [Was passiert?]
+2. **Hinweisrunde 1:** [Ablauf + Timing]
+3. **Hinweisrunde 2:** [Ablauf + Timing]
+4. **Hinweisrunde 3:** [Ablauf + Timing]
+5. **Gerüchterunde (optional):** [Ablauf + Timing]
+6. **Auflösung:** [Ablauf + Timing]
+
+## Regeln (Kurzfassung)
+- **Wahrheitspflicht:** [Regeltext]
+- **Lügenregel:** [Regeltext]
+- **Improvisation:** [Regeltext]
+- **Umgang mit Wissenslücken:** [Regeltext]
+
+## Einführungstext (Vorlesetext)
+[Platzhalter für den Vorlesetext zur Spiel-Eröffnung.]


### PR DESCRIPTION
### Motivation
- Ensure a consistent single source of truth for all documents required to produce a playable Krimi‑Dinner without introducing story content. 
- Provide clear, fillable structures so later work can focus on populating requirements (roles, Hinweise, Auflösung) while keeping format and obligations consistent. 
- Follow the repository's requirement-gathering approach by offering templates that capture only structure and constraints, not narrative details.

### Description
- Add a `templates/` directory containing a `README.md` and template files for all mandatory documents such as `spielanleitung-material-einfuehrungstext.md`, `einladung.md`, `rollenbeschreibung.md`, `hinweise.md`, `ermittlungsergebnisse-inspektor.md`, `aufloesung.md`, and others. 
- Each template uses placeholders in square brackets (e.g. `[Name der Rolle]`) and explicitly avoids story text, focusing on required fields, rounds, and artifact structure. 
- Templates include operational aids like `hinweisuebersicht-pro-runde.md`, `kurzfassung-pro-runde.md`, and `entscheidendes-merkmal.md` to support consistency and validation of hint coverage across rounds.

### Testing
- No automated tests were executed because this change only adds documentation templates. 
- Templates were inspected for presence and basic readability by listing and displaying the files in the new `templates/` directory. 
- No runtime or integration impacts are expected from these documentation-only additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875396feb88325858417e171e43ebf)